### PR TITLE
Add documentation strings

### DIFF
--- a/PyCD/constants.py
+++ b/PyCD/constants.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Collection of physical constants used throughout the package."""
+
 # CONSTANTS
 EPSILON0 = 8.854187817E-12  # Electric constant in F.m-1
 ANG = 1E-10  # Angstrom in m

--- a/PyCD/io.py
+++ b/PyCD/io.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""I/O helper routines used for preparing and analyzing simulations."""
+
 from datetime import datetime
 
 import numpy as np

--- a/PyCD/material_coc_msd.py
+++ b/PyCD/material_coc_msd.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Scripts to compute center-of-charge mean squared displacement."""
+
 import os
 
 import yaml

--- a/PyCD/material_msd.py
+++ b/PyCD/material_msd.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Convenience functions for computing mean squared displacement."""
+
 import numpy as np
 import yaml
 

--- a/PyCD/material_preprod.py
+++ b/PyCD/material_preprod.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Prepare simulation data before running kinetic Monte Carlo."""
+
 import numpy as np
 import yaml
 

--- a/PyCD/material_run.py
+++ b/PyCD/material_run.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Entry points for executing kinetic Monte Carlo simulations."""
+
 import numpy as np
 import yaml
 

--- a/PyCD/material_setup.py
+++ b/PyCD/material_setup.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Utilities to set up material objects and neighbor data for simulations."""
+
 import numpy as np
 import yaml
 

--- a/PyCD/scripts/__init__.py
+++ b/PyCD/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Utility scripts for analyzing and post-processing PyCD simulations."""

--- a/PyCD/scripts/coc_msd.py
+++ b/PyCD/scripts/coc_msd.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Command-line helper to compute center-of-charge MSD from trajectories."""
+
 from datetime import datetime
 
 import numpy as np

--- a/PyCD/scripts/data_profile.py
+++ b/PyCD/scripts/data_profile.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Generate diffusivity and runtime profiles from simulation outputs."""
+
 from textwrap import wrap
 from datetime import timedelta
 
@@ -10,6 +12,33 @@ import matplotlib.pyplot as plt
 
 
 class DataProfile(object):
+    """Generate diffusivity and runtime statistics over many runs.
+
+    Parameters
+    ----------
+    dst_path : pathlib.Path
+        Destination directory for generated profiles.
+    system_directory_path : pathlib.Path
+        Root directory containing simulation results.
+    variable_quantity_type_index : int
+        Index describing which quantity is varied across runs.
+    variable_quantity_index : int
+        Species index varied when ``variable_quantity_type_index`` equals 1.
+    variable_quantity_list : list
+        Sequence of values for the variable quantity.
+    species_count : list
+        Base count of [electrons, holes].
+    t_final : float
+        Simulation end time.
+    time_interval : float
+        Time step used in the simulation.
+    n_traj : int
+        Number of trajectories per run.
+    external_field : dict
+        Dictionary describing external field parameters.
+    doping : dict
+        Dictionary with doping information.
+    """
     def __init__(self, dst_path, system_directory_path,
                  variable_quantity_type_index, variable_quantity_index,
                  variable_quantity_list, species_count,
@@ -48,6 +77,18 @@ class DataProfile(object):
         return None
 
     def generate_work_dir_path(self, species_count):
+        """Create the directory path for a given species configuration.
+
+        Parameters
+        ----------
+        species_count : sequence of int
+            Two-element iterable containing the numbers of electrons and holes.
+
+        Returns
+        -------
+        pathlib.Path
+            Path to the corresponding simulation directory.
+        """
         (n_electrons, n_holes) = species_count
         parent_dir1 = 'SimulationFiles'
         parent_dir2 = (str(n_electrons)

--- a/PyCD/scripts/generate_msd_analytical_data.py
+++ b/PyCD/scripts/generate_msd_analytical_data.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Generate analytical MSD data for validation of simulations."""
+
 from datetime import datetime
 
 import numpy as np

--- a/PyCD/scripts/generate_species_site_sd_list.py
+++ b/PyCD/scripts/generate_species_site_sd_list.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Create species-site squared displacement data for analytical analysis."""
+
 from datetime import datetime
 
 import numpy as np

--- a/PyCD/scripts/generate_transition_prob_matrix.py
+++ b/PyCD/scripts/generate_transition_prob_matrix.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Utility to generate transition probability matrices for analytical MSD."""
+
 from datetime import datetime
 
 import numpy as np

--- a/PyCD/scripts/mean_distance.py
+++ b/PyCD/scripts/mean_distance.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+"""Compute the mean distance between charge carriers from trajectory data."""
+
 from datetime import datetime
 
 import numpy as np


### PR DESCRIPTION
## Summary
- add module-level docstrings across scripts and modules
- document `DataProfile` class and `generate_work_dir_path`

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841435efe008329851760fd30cf30d9